### PR TITLE
Brute force finding phone number without +

### DIFF
--- a/phone/iso.go
+++ b/phone/iso.go
@@ -46,10 +46,12 @@ func GetISO3166ByPhone(phone string) (*PhoneData, error) {
 	lenOfPhoneNum := len(phone)
 
 	for _, v := range ISO3166_Data {
-		if reg, err := regexp.Compile(fmt.Sprintf("^%s", v.CountryCode)); err == nil {
+		if reg, err := regexp.Compile(fmt.Sprintf("^%s", v.CountryCode)); err == nil && reg.MatchString(phone) {
+
+			lenOfCountryCode := len(v.CountryCode)
 
 			for _, x := range v.PhoneNumberLengths {
-				if reg.MatchString(phone) && lenOfPhoneNum == (len(v.CountryCode)+x) {
+				if lenOfPhoneNum == (lenOfCountryCode + x) {
 					// it match.. but may have more than one result.
 					// e.g. USA and Canada. need to check mobileBeginWith
 
@@ -65,7 +67,7 @@ func GetISO3166ByPhone(phone string) (*PhoneData, error) {
 				}
 			}
 
-		} else {
+		} else if err != nil {
 			return nil, err
 		}
 	}

--- a/phone/normaliser.go
+++ b/phone/normaliser.go
@@ -163,11 +163,17 @@ func normaliseWithoutCountry(phone string, hasPlusSign bool) (*Result, error) {
 		} else {
 			return nil, ErrPhoneMiss
 		}
-	} else {
-		lenOfPhoneNum := len(phone)
-		if containsInt(data.PhoneNumberLengths, lenOfPhoneNum) {
-			phone = fmt.Sprintf("1%s", phone)
-		}
+	}
+
+	// Let's try and brute force it anyway.
+	if possible, err := GetISO3166ByPhone(phone); err == nil && possible != nil {
+		return NewResult(phone, possible), nil
+	}
+
+	// We really have no idea what this phone number is!
+	lenOfPhoneNum := len(phone)
+	if containsInt(data.PhoneNumberLengths, lenOfPhoneNum) {
+		phone = fmt.Sprintf("1%s", phone)
 	}
 
 	return NewResult(phone, data), nil

--- a/phone/normaliser_test.go
+++ b/phone/normaliser_test.go
@@ -6,6 +6,50 @@ import (
 	"testing/quick"
 )
 
+func Test_Phone_IRL_without_country(t *testing.T) {
+	makeNum := func(a uint) string {
+		mod := a % 1
+		return fmt.Sprintf("35387%v09%v54%v", mod, mod, mod)
+	}
+	prepare := func(a string) string {
+		res, _ := normalisePhoneNumber(a)
+		return fmt.Sprintf("+%s", res)
+	}
+
+	f := func(x uint) *PhoneResult {
+		return NewPhoneResult(prepare(makeNum(x)), "IRL")
+	}
+	g := func(x uint) *PhoneResult {
+		res, _ := Normalise(makeNum(x), "")
+		return res
+	}
+	if err := quick.CheckEqual(f, g, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_Phone_IRL_with_country(t *testing.T) {
+	makeNum := func(a uint) string {
+		mod := a % 1
+		return fmt.Sprintf("+35387%v09%v54%v", mod, mod, mod)
+	}
+	prepare := func(a string) string {
+		res, _ := normalisePhoneNumber(a)
+		return fmt.Sprintf("+%s", res)
+	}
+
+	f := func(x uint) *PhoneResult {
+		return NewPhoneResult(prepare(makeNum(x)), "IRL")
+	}
+	g := func(x uint) *PhoneResult {
+		res, _ := Normalise(makeNum(x), "")
+		return res
+	}
+	if err := quick.CheckEqual(f, g, nil); err != nil {
+		t.Error(err)
+	}
+}
+
 func Test_Phone_GB_without_country(t *testing.T) {
 	makeNum := func(a uint) string {
 		mod := a % 1


### PR DESCRIPTION
If the phone number doesn't have a plus, go through and check all the possibilities.
Although this is slower, it's actually safe because this is what it does with a + and we
don't actually care if it doesn't fine one.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dicefm/extraterrestrial/1)

<!-- Reviewable:end -->
